### PR TITLE
Combat Overhaul Patch, Fix Spear Tool Tier

### DIFF
--- a/ElectricalProgressive-Equipment/assets/electricalprogressiveequipment/itemtypes/weapon/static-spear.json
+++ b/ElectricalProgressive-Equipment/assets/electricalprogressiveequipment/itemtypes/weapon/static-spear.json
@@ -8,6 +8,7 @@
 	"heldTpIdleAnimation": "spearidle",
 	"heldRightReadyAnimation": "spearidle",
 	"attackRange": 4.0,
+    "tooltier": 6,
 	"attackpower": 7,
   "durability": 1000,
 	"attributes": {

--- a/ElectricalProgressive-Equipment/assets/electricalprogressiveequipment/patches/patchweapons.json
+++ b/ElectricalProgressive-Equipment/assets/electricalprogressiveequipment/patches/patchweapons.json
@@ -1,0 +1,31 @@
+﻿[
+    {
+        "file": "electricalprogressiveequipment:itemtypes/weapon/static-spear.json",
+        "op": "replace",
+        "path": "/attackpower" ,
+        "value": 7.7,
+        "dependsOn": [{"modid": "combatoverhaul"}]
+    },
+    {
+        "file": "electricalprogressiveequipment:itemtypes/weapon/static-spear.json",
+        "op": "add",
+        "path": "/attributes/ProficiencyStat",
+        "value": "spearsProficiency",
+        "dependsOn": [{"modid": "combatoverhaul"}]
+    },
+
+    {
+        "file": "electricalprogressiveequipment:itemtypes/weapon/static-saber.json",
+        "op": "replace",
+        "path": "/attackpower",
+        "value": 8.8,
+        "dependsOn": [{"modid": "combatoverhaul"}]
+    },
+    {
+        "file": "electricalprogressiveequipment:itemtypes/weapon/static-saber.json",
+        "op": "add",
+        "path": "/attributes/ProficiencyStat",
+        "value": "oneHandedSwordsProficiency",
+        "dependsOn": [{"modid": "combatoverhaul"}]
+    }
+]


### PR DESCRIPTION
Combat Overhaul now supported manually. While this wont allow fancy swing types it will at least increase the damage like combat overhaul does and allow proficiency to take affect.
Also fixes spear not having a tool tier.

Below is the above auto translated to Russian; I hope it translated well...

Теперь ручная поддержка Combat Overhaul. Хотя это не позволит использовать сложные типы ударов, это, по крайней мере, увеличит урон, как и Combat Overhaul, и позволит учитывать уровень мастерства. Также исправлена проблема с тем, что копье не имело уровня инструмента.